### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-execution.yml
+++ b/.github/workflows/test-execution.yml
@@ -7,6 +7,9 @@ on:
       - dev
       - test
 
+permissions:
+  contents: read
+
 jobs:
   dry-run:
     name: Dry Run Tests


### PR DESCRIPTION
Potential fix for [https://github.com/buildplan/container-monitor/security/code-scanning/2](https://github.com/buildplan/container-monitor/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only needs to read the repository contents (e.g., for checking out the code), we will set `contents: read` as the minimal required permission. This block will be added at the root of the workflow, applying to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
