### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/buildplan/container-monitor/security/code-scanning/1](https://github.com/buildplan/container-monitor/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow. Since the workflow only checks out the repository and runs a linting tool, it only needs `contents: read` permission. This ensures that the workflow has the least privilege necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
